### PR TITLE
button style aligned to rest of app, opacity increased on text, sligh…

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -15,12 +15,13 @@
 .banner p {
   font-size: 20px;
   color: white;
-  opacity: .7;
+  opacity: .9;
   text-shadow: 1px 1px 3px rgba(0,0,0,0.2);
 }
 
 .start-button {
   color: white;
+  border-radius: 7px;
 }
 
 .text-grey {

--- a/app/assets/stylesheets/components/_reg_forms.scss
+++ b/app/assets/stylesheets/components/_reg_forms.scss
@@ -132,3 +132,7 @@
     text-align: center;
   }
 }
+
+nav-link {
+  background-color: var(--bs-nav-pills-link-dark-bg, $medium_green);
+}

--- a/app/views/meals/index.html.erb
+++ b/app/views/meals/index.html.erb
@@ -109,7 +109,7 @@
         <% end %>
         <hr>
         <p>
-          <strong>total for meal: <%= dinner.total_calories.to_i %> kcal</strong>
+          <strong>Total for meal: <%= dinner.total_calories.to_i %> kcal</strong>
           <%= link_to "<i class='fa fa-trash'></i>".html_safe, meal_path(dinner), data: {turbo_method: :delete, turbo_confirm: "Are you sure?" } %>
         </p>
       <% end %>
@@ -130,7 +130,7 @@
         <% end %>
         <hr>
         <p>
-          <strong>total for meal: <%= snack.total_calories.to_i %> kcal</strong>
+          <strong>Total for meal: <%= snack.total_calories.to_i %> kcal</strong>
           <%= link_to "<i class='fa fa-trash'></i>".html_safe, meal_path(snack), data: {turbo_method: :delete, turbo_confirm: "Are you sure?" } %>
         </p>
       <% end %>

--- a/app/views/meals/new.html.erb
+++ b/app/views/meals/new.html.erb
@@ -8,14 +8,14 @@
           <div data-toggle-target="togglableElement" class="d-none">
             <%= f.simple_fields_for :portions do |portion_fields| %>
               <div data-ingredients-target="ingredients" class="weight-space">
-                <%= portion_fields.association :ingredient, collection: Ingredient.all.order(:name), prompt: "Select ingredient" %>
+                <%= portion_fields.association :ingredient, label:false, collection: Ingredient.all.order(:name), prompt: "Select ingredient" %>
               </div>
               <button type="button" class="btn btn-outline-dark-green" data-bs-toggle="modal" data-bs-target="#exampleModal">
                 Find new ingredients
               </button>
 
               <div class="weight-space">
-                <%= portion_fields.input :quantity, label:"Weight", placeholder:"Weight in g/ml " %>
+                <%= portion_fields.input :quantity, label: false, placeholder:"Weight in g/ml " %>
               </div>
             <% end %>
             <%= f.submit "Add", class:"btn btn-signup meals-button" %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -7,9 +7,10 @@
     <p style="padding-left: 1em;"> 3. Stay motivated and reach your goals.</p>
     <% if user_signed_in? %>
       <p style="margin-top: 20px;">Welcome Back! <%= current_user.username%></p>
-      <a class="btn btn-dark-green start-button" href="/account">Start your journey</a>
+      <br>
+      <a class="btn btn-lg btn-dark-green start-button" href="/account">Start your journey</a>
     <% else %>
-      <a class="btn btn-dark-green start-button" href="users/sign_in">Get Started</a>
+      <a class="btn btn-lg btn-dark-green start-button" href="users/sign_in">Get Started</a>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
Opacity increased for <p> text on landing page, as per Ben's feedback. Button on landing page made slightly larger with border-radius to match size and shape of buttons elsewhere, very slight alteration to line spacing to make button standout from text a little. Previous changes unsure if they have been pulled ie removing bold from tab headings as per Jake's feedback.